### PR TITLE
Ignore exceptions caused in package

### DIFF
--- a/honeybadger-client/src/main/java/com/workable/honeybadger/HoneybadgerClient.java
+++ b/honeybadger-client/src/main/java/com/workable/honeybadger/HoneybadgerClient.java
@@ -128,6 +128,19 @@ public class HoneybadgerClient {
      *                                 dispatched
      * @param excludedExceptionClasses Comma delimited list of Exceptions that should be ignored
      */
+    public HoneybadgerClient(String apiKey, String excludedSysProps, String excludedExceptionClasses) {
+        this(apiKey, excludedSysProps, excludedExceptionClasses, null);
+    }
+
+    /**
+     * Constructs a Client with specific options
+     *
+     * @param apiKey                   The Honeybadger API Key
+     * @param excludedSysProps         Comma delimited list of System properties that should be excluded from errors
+     *                                 dispatched
+     * @param excludedExceptionClasses Comma delimited list of Exceptions that should be ignored
+     * @param excludedExceptionCauses  Comma delimited list of packages or classes that throw exceptions to ignore
+     */
     public HoneybadgerClient(String apiKey, String excludedSysProps, String excludedExceptionClasses, String excludedExceptionCauses) {
         this.apiKey = apiKey;
         this.excludedExceptionClasses = buildExcludedClasses(excludedExceptionClasses);
@@ -232,11 +245,13 @@ public class HoneybadgerClient {
             }
         }
 
-        StackTraceElement[] stackTraceElements = error.getStackTrace();
-        if (stackTraceElements != null && stackTraceElements.length > 0) {
-            for (String className : excludedExceptionCauses) {
-                if (stackTraceElements[0].getClassName().startsWith(className)) {
-                    return true;
+        if (!excludedExceptionCauses.isEmpty()) {
+            StackTraceElement[] stackTraceElements = error.getStackTrace();
+            if (stackTraceElements != null && stackTraceElements.length > 0) {
+                for (String className : excludedExceptionCauses) {
+                    if (stackTraceElements[0].getClassName().startsWith(className)) {
+                        return true;
+                    }
                 }
             }
         }

--- a/honeybadger-client/src/test/java/com/workable/honeybadger/HoneybadgerClientTest.java
+++ b/honeybadger-client/src/test/java/com/workable/honeybadger/HoneybadgerClientTest.java
@@ -1,0 +1,22 @@
+package com.workable.honeybadger;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class HoneybadgerClientTest {
+
+    @Test
+    public void testShouldExclude() {
+        HoneybadgerClient client;
+
+        client = new HoneybadgerClient(null, null, null, "com.workable.honeybadger");
+        assertThat(client.shouldExclude(new IOException("This is a test")), is(true));
+
+        client = new HoneybadgerClient(null, null, null, "com.workable.honeybadger.test");
+        assertThat(client.shouldExclude(new IOException("This is a test")), is(false));
+    }
+}

--- a/honeybadger-log4j-appender/src/main/java/com/workable/honeybadger/log4j/HoneybadgerAppender.java
+++ b/honeybadger-log4j-appender/src/main/java/com/workable/honeybadger/log4j/HoneybadgerAppender.java
@@ -33,6 +33,11 @@ public class HoneybadgerAppender extends AppenderSkeleton {
     private String ignoredExceptions;
 
     /**
+     * Comma delimited list of classes or packages that cause Exceptions that should be ignored
+     */
+    private String ignoredCauses;
+
+    /**
      * If <code>true</code> erros are dispatched asynchronously (Default true)
      */
     private boolean async = true;
@@ -70,7 +75,7 @@ public class HoneybadgerAppender extends AppenderSkeleton {
     public void activateOptions() {
         super.activateOptions();
         if (client == null) {
-            client = new HoneybadgerClient(apiKey, ignoredSystemProperties, ignoredExceptions);
+            client = new HoneybadgerClient(apiKey, ignoredSystemProperties, ignoredExceptions, ignoredCauses);
             client.setAsync(async);
             client.setMaxThreads(maxThreads);
             client.setPriority(priority);
@@ -98,6 +103,10 @@ public class HoneybadgerAppender extends AppenderSkeleton {
 
     public void setIgnoredExceptions(String ignoredExceptions) {
         this.ignoredExceptions = ignoredExceptions;
+    }
+
+    public void setIgnoredCauses(String ignoredCauses) {
+        this.ignoredCauses = ignoredCauses;
     }
 
     public void setAsync(boolean async) {

--- a/honeybadger-logback-appender/src/main/java/com/workable/honeybadger/logback/HoneybadgerAppender.java
+++ b/honeybadger-logback-appender/src/main/java/com/workable/honeybadger/logback/HoneybadgerAppender.java
@@ -1,12 +1,13 @@
 package com.workable.honeybadger.logback;
 
+import com.workable.honeybadger.Error;
+import com.workable.honeybadger.HoneybadgerClient;
+
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.StackTraceElementProxy;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.core.AppenderBase;
-import com.workable.honeybadger.Error;
-import com.workable.honeybadger.HoneybadgerClient;
 
 
 /**
@@ -33,6 +34,11 @@ public class HoneybadgerAppender extends AppenderBase<ILoggingEvent> {
      * Comma delimited list of Exceptions that should be ignored
      */
     private String ignoredExceptions;
+
+    /**
+     * Comma delimited list of classes or packages that cause Exceptions that should be ignored
+     */
+    private String ignoredCauses;
 
     /**
      * If <code>true</code> erros are dispatched asynchronously (Default true)
@@ -63,11 +69,12 @@ public class HoneybadgerAppender extends AppenderBase<ILoggingEvent> {
     /**
      * Creates an instance of HoneybadgerAppender.
      */
-    public HoneybadgerAppender(HoneybadgerClient client, String apiKey, String ignoredExceptions, String ignoredSystemProperties,
-                               boolean async, int maxThreads, int priority, int queueSize) {
+    public HoneybadgerAppender(HoneybadgerClient client, String apiKey, String ignoredExceptions, String ignoredCauses,
+                               String ignoredSystemProperties, boolean async, int maxThreads, int priority, int queueSize) {
         this.client = client;
         this.apiKey = apiKey;
         this.ignoredExceptions = ignoredExceptions;
+        this.ignoredCauses = ignoredCauses;
         this.ignoredSystemProperties = ignoredSystemProperties;
         this.async = async;
         this.maxThreads = maxThreads;
@@ -105,7 +112,7 @@ public class HoneybadgerAppender extends AppenderBase<ILoggingEvent> {
     protected synchronized void initHoneybadger() {
         try {
             if (client == null) {
-                client = new HoneybadgerClient(apiKey, ignoredSystemProperties, ignoredExceptions);
+                client = new HoneybadgerClient(apiKey, ignoredSystemProperties, ignoredExceptions, ignoredCauses);
                 client.setAsync(async);
                 client.setMaxThreads(maxThreads);
                 client.setPriority(priority);
@@ -144,6 +151,10 @@ public class HoneybadgerAppender extends AppenderBase<ILoggingEvent> {
 
     public void setIgnoredExceptions(String ignoredExceptions) {
         this.ignoredExceptions = ignoredExceptions;
+    }
+
+    public void setIgnoredCauses(String ignoredCauses) {
+        this.ignoredCauses = ignoredCauses;
     }
 
     public void setAsync(boolean async) {

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 
     <properties>
         <org.glassfish.jersey.version>2.3.1</org.glassfish.jersey.version>
+        <org.codehaus.mojo.versions-maven-plugin.version>2.5</org.codehaus.mojo.versions-maven-plugin.version>
     </properties>
 
     <profiles>
@@ -128,10 +129,12 @@
                     <target>1.7</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>${org.codehaus.mojo.versions-maven-plugin.version}</version>
+            </plugin>
         </plugins>
     </build>
-
-
-
 
 </project>


### PR DESCRIPTION
With this modification we will be able to handle cases like

```
Could not read ToUnicode CMap in font ATDKRW+Calibri-Light
  1 java.io.IOException: Error : ~bfchar contains an unexpected operator : endcmap
  2 at org.apache.fontbox.cmap.CMapParser.parseBeginbfchar(CMapParser.java:259)
  3 at org.apache.fontbox.cmap.CMapParser.parse(CMapParser.java:132)
```
By adding `org.apache.fontbox.cmap` or `org.apache.fontbox` we can exclude all error caused by that invocation. It looks only for the last invocation.